### PR TITLE
Update AMQPUtils dependencies to AnyObject 1.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>mx.bigdata.utils</groupId>
   <artifactId>amqp-utils</artifactId>
-  <version>1.1.1-SNAPSHOT</version>
+  <version>1.1.2-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <parent>
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>mx.bigdata.anyobject</groupId>
       <artifactId>anyobject</artifactId>
-      <version>0.9.3</version>
+      <version>1.0.0</version>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
This will allow all projects that depend on AMQPUtils to naturally (no exclusion tags in pom files) enjoy of the Loader interface that JSON and Yaml loaders now implement.

As AMQPUtils doesn't depend on those loaders (only on AnyObject itself) this change doesn't need any further change in the sources of AMQPUtils themselves.
